### PR TITLE
fix(htl): invalid last modified date (#59)

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -50,7 +50,7 @@
                     <h1>${content.title}</h1>
                     <div data-sly-test="${content.committers && content.lastModified}" class="author">
                         <sly data-sly-list="${content.committers}"><img title="${item.display}" src="${item.avatar_url}"></sly>
-                        <span class="lastModified">Last modified <time datetime="${content.lastModified.raw}">${content.lastModified.display}</time></span>
+                        <span class="lastModified">Last modified <time>${content.lastModified.raw}</time></span>
                     </div>
                 </div>
                 <div data-sly-test="${content.document}">${content.document.body.innerHTML @ context = 'unsafe'}</div>
@@ -62,7 +62,7 @@
             const parent = document.getElementsByClassName('lastModified')[0];
 
             const elem = parent.children[0];
-            const lastMod = elem.getAttribute('datetime');
+            const lastMod = elem.innerHTML;
             elem.innerHTML = moment(lastMod).fromNow();
             parent.className += ' visible';
 


### PR DESCRIPTION
Moment.js chokes on the XSS encoded raw date value which it extracts from`<time datetime="...">`. It looks like this value is always encoded. I couldn't get it to skip, even with `@ context = 'unsafe'`...

As a workaround, I now moved the raw value from the attribute to the body of the `<time>` tag. The display value that was in there before was never displayed anyway.

Fixes #59 