### PR TITLE
fix(test.hlx.up) adapt test according to adobe/helix-cli#913

### DIFF
--- a/test/smoke/test.hlx.up.js
+++ b/test/smoke/test.hlx.up.js
@@ -25,7 +25,7 @@ describe('project-helix.io renders properly', function suite() {
   let hlxup;
 
   before(async () => {
-    hlxup = $.exec(`${HLX_SMOKE_EXEC} up --open false`, {
+    hlxup = $.exec(`${HLX_SMOKE_EXEC} up --no-local-repo --open false`, {
       // silent: true,
       async: true,
     }, (code, stdout) => {


### PR DESCRIPTION
adobe/helix-cli#913 and PR adobe/helix-cli#1149 make the `--local-repo .` option the implicit default. The smoke test must be adapted accordingly.